### PR TITLE
Fixing slector parsing by skipping TRACE lines

### DIFF
--- a/test/HelperContract.sol
+++ b/test/HelperContract.sol
@@ -22,7 +22,6 @@ abstract contract HelperContract is IDiamond, IDiamondLoupe, Test{
     internal
     returns (bytes4[] memory selectors)
     {
-
         //get string of contract methods
         string[] memory cmd = new string[](4);
         cmd[0] = "forge";
@@ -34,19 +33,27 @@ abstract contract HelperContract is IDiamond, IDiamondLoupe, Test{
 
         // extract function signatures and take first 4 bytes of keccak
         strings.slice memory s = st.toSlice();
-        strings.slice memory delim = ":".toSlice();
-        strings.slice memory delim2 = ",".toSlice();
-        selectors = new bytes4[]((s.count(delim)));
-        for(uint i = 0; i < selectors.length; i++) {
-            s.split('"'.toSlice());
-            selectors[i] = bytes4(s.split(delim).until('"'.toSlice()).keccak());
-            s.split(delim2);
 
+        // Skip TRACE lines if any
+        strings.slice memory nl = '\n'.toSlice();
+        strings.slice memory trace = 'TRACE'.toSlice();
+        while (s.contains(trace) ) {
+            s.split(nl);
+        }
+
+        strings.slice memory colon = ":".toSlice();
+        strings.slice memory comma = ",".toSlice();
+        strings.slice memory dbquote = '"'.toSlice();
+        selectors = new bytes4[]((s.count(colon)));
+
+        for(uint i = 0; i < selectors.length; i++) {
+            s.split(dbquote);   // advance to next doublequote
+            // split at colon, extract string up to next doublequote for methodname
+            strings.slice memory method = s.split(colon).until(dbquote);
+            selectors[i] = bytes4(method.keccak());
+            strings.slice memory selectr = s.split(comma).until(dbquote);     // advance s to the next comma
         }
         return selectors;
-
-
-
     }
 
 // helper to remove index from bytes4[] array


### PR DESCRIPTION
	modified:   test/HelperContract.sol

When RUST_LOG=forge is set in the environment (for debugging tests) the environment gets passed to the forge inspect ffi command inside generateSelectors which causes the parsing to fail. This code adds a way to skip the first lines that contain the word TRACE until the first curly brace.
I also cleaned up the slice manipulation to avoid declaring delimiters several times.